### PR TITLE
Added gradle-wrapper.properties

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Hi, I use your plugin in my Flutter module, and when I try build aar, I got next error:

> ProcessException: ProcessException: Process "/Users/user/Development/flutter/.pub-cache/git/flutter_string_encryption-3e4b96d4281e61ead4e2280e2662e4158d1f4483/android/gradlew" exited abnormally:
Exception in thread "main" java.lang.RuntimeException: Wrapper properties file '/Users/user/Development/flutter/.pub-cache/git/flutter_string_encryption-3e4b96d4281e61ead4e2280e2662e4158d1f4483/android/gradle/wrapper/**gradle-wrapper.properties' does not exist.**
	at org.gradle.wrapper.WrapperExecutor.forWrapperPropertiesFile(WrapperExecutor.java:45)
	at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:60)

Could you accept my PR to avoid the error?